### PR TITLE
Revert "Add Linux build support and update manifest with Linux configuration"

### DIFF
--- a/.github/workflows/build-package-norelease.yml
+++ b/.github/workflows/build-package-norelease.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: build for osx
         run: dotnet publish -c Release --runtime osx-x64 -o build streamdeck-vtubestudio
-      - name: build for Linux
-        run: dotnet publish -c Release --runtime linux-x64 -o build/linux streamdeck-vtubestudio
 
       - uses: jossef/action-set-json-field@v2.2
         with:

--- a/streamdeck-vtubestudio/manifest.json
+++ b/streamdeck-vtubestudio/manifest.json
@@ -192,7 +192,6 @@
   "CodePath": "streamdeck-vtubestudio",
   "CodePathWin": "streamdeck-vtubestudio.exe",
   "CodePathMac": "streamdeck-vtubestudio",
-  "CodePathLin": "linux/streamdeck-vtubestudio",
   "Category": "VTubeStudio [Cazzar]",
   "CategoryIcon": "vts_logo_transparent",
   "OS": [
@@ -203,9 +202,6 @@
     {
       "Platform": "mac",
       "MinimumVersion": "10.11"
-    },
-    {
-      "Platform": "linux"
     }
   ],
   "SDKVersion": 2,


### PR DESCRIPTION
Reverts Cazzar/VTubeStudio-StreamDeck#41

Build broke - so reverting this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Linux platform support. Linux binaries are no longer built or distributed.
  * Updated the plugin manifest to drop Linux entries, retaining Windows and macOS only.
  * Packaging and versioning steps remain unchanged.

* **Impact**
  * Windows and macOS users are unaffected.
  * Linux users will no longer receive new builds; future versions may not run on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->